### PR TITLE
Add const constructor to None and getOrNull to Option

### DIFF
--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -19,10 +19,13 @@ abstract class Option<A> {
   /// True if None else false
   bool get isEmpty => !isDefined;
 
-  /// Return [a] inside [Some] else  supplied [caseElse] if None
+  /// Return [a] inside [Some] else supplied [caseElse] if None
   A? getOrElse(A? Function() caseElse) => fold(caseElse, (A a) => a);
 
-  /// Return inchanged Option if [Some] else supplied [caseElse] if None
+  /// Return [a] inside [Some] else null if None
+  A? getOrNull() => fold(() => null, (A a) => a);
+
+  /// Return unchanged Option if [Some] else supplied [caseElse] if None
   Option orElse<B>(Option<B> Function() caseElse) =>
       fold(caseElse, (A a) => this); // or  (A a) => some(a)
 

--- a/lib/src/option.dart
+++ b/lib/src/option.dart
@@ -2,6 +2,8 @@ import 'package:either_option/src/either.dart';
 
 ///Simple Option monad implementation
 abstract class Option<A> {
+  const Option();
+
   /// Return [None] Option
   static Option<A> empty<A>() => _none();
 
@@ -78,6 +80,8 @@ class Some<A> extends Option<A> {
 }
 
 class None<A> extends Option<A> {
+  const None();
+
   @override
   bool operator ==(that) => that is None;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  test: ^1.16.4
+  test: ">=1.21.0 <2.0.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec

--- a/test/option_test.dart
+++ b/test/option_test.dart
@@ -43,9 +43,13 @@ void main() {
       expect(a.fold(() => "ko", (_) => "ok"), "ko");
       expect(b.fold(() => "ko", (_) => "ok"), "ok");
 
-      /// getorElse
+      /// getOrElse
       expect(a.getOrElse(() => 0), 0);
       expect(b.getOrElse(() => 0), 2);
+
+      /// getOrNull
+      expect(a.getOrNull(), null);
+      expect(b.getOrNull(), 2);
 
       /// orElse
       expect(a.orElse(() => Some("0")), Some("0"));


### PR DESCRIPTION
This PR consists of 2 commits:
1. [Add const constructor to None](https://github.com/cbyad/either_option/commit/3e9e3b503a790394754f24095352adf77856e956)

Allows for specifying `None` as default constructor parameter:
```dart
class Foo {
  Foo({
    Option<String> param = const None(),
  });
}
```

2. [Add getOrNull method to Option](https://github.com/cbyad/either_option/commit/ca4f8ee2facd1140a3d02c452e3af1726d83e710)

This one's pretty self-explanatory, as seen in tests:
```dart
/// getOrNull
expect(a.getOrNull(), null);
expect(b.getOrNull(), 2);
```